### PR TITLE
Support publishing to jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11


### PR DESCRIPTION
You couldn't grab the artifact from jitpack because of the source level. Adding this file configures jitpack to compile with JDK 11