### PR TITLE
Allow no email/password for device authentication

### DIFF
--- a/src/main/java/athena/Athena.java
+++ b/src/main/java/athena/Athena.java
@@ -498,8 +498,10 @@ public interface Athena {
          * @throws EpicGamesErrorException   if there was an authentication exception
          */
         public Athena build() throws UnsupportedBuildException, EpicGamesErrorException {
-            if (email == null || email.isEmpty()) throw new UnsupportedBuildException("Athena needs an email address to login.");
-            if (password == null || password.isEmpty()) throw new UnsupportedBuildException("Athena needs a password to login.");
+            if (grantType != GrantType.DEVICE_AUTH) {
+                if (email == null || email.isEmpty()) throw new UnsupportedBuildException("Athena needs an email address to login.");
+                if (password == null || password.isEmpty()) throw new UnsupportedBuildException("Athena needs a password to login.");
+            }
             if (enableXmpp && (platform == null || appType == null)) throw new UnsupportedBuildException("Platform and app must be set for XMPP.");
             if (kairos && authorizationToken.equals(EPIC_GAMES_LAUNCHER_TOKEN)) authorizationToken = KAIROS_TOKEN;
             return new AthenaImpl(this);


### PR DESCRIPTION
If you don't fill the email/password field with any string that isn't empty when you want to authenticate with device auth, it will error; even though the email and password field is unused for device auth authentication.